### PR TITLE
Re-instantiate socket to attempt TLSv1 without error.

### DIFF
--- a/MumbleConnection.py
+++ b/MumbleConnection.py
@@ -77,6 +77,8 @@ class MumbleConnection(AbstractConnection.AbstractConnection):
 			self._socket = ssl.wrap_socket(s)
 		except ssl.SSLError:
 			try:
+				s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+				s.connect((self._hostname, self._port))
 				self._log("python default ssl connection failed, trying TLSv1", 3)
 				self._socket = ssl.wrap_socket(s, ssl_version = ssl.PROTOCOL_TLSv1)
 			except ssl.SSLError:


### PR DESCRIPTION
Added on line 80:

``` python
                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                s.connect((self._hostname, self._port))
```
