### PR TITLE
Fixed SSL Certificate Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ You need to provide a config file that (among others) contains user credentials 
 
 You can either specify a conf file path as a command line argument (`sftbot myconffile.conf`), or place it at `./sftbot.conf` or `/etc/sftbot.conf`.
 
+#### Generating Self-Signed Certificates ####
+
+You can generate a self-signed SSL certificate for the bot by running the following line in the root of the sftmumblebot installation:
+`$ openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem`
+
+If you permanently install the script, you should specificy an absolute path in front of the certicates on the `sftbot.config` file.
+
 ### Behaviour
 
 By default, the bot
@@ -32,8 +39,8 @@ More complex, 'botty' behaviour may be implemented the same way; note that you c
 
 Nice-to-have features (which we don't plan to implement right now, but feel free to do it yourself):
 
-- SSL certificate validation support
-- SSL client certificate support
+- ~~SSL certificate validation support~~
+- ~~SSL client certificate support~~
 - More chat protocols (e.g. XMPP multi-user chat)
 - Init scripts for `<your distribution here>`
 

--- a/sftbot.conf.example
+++ b/sftbot.conf.example
@@ -3,6 +3,8 @@
 [mumble]
 server=mumble.example.com
 port=64738                 ; mumble default port
+keyfile=key.pem            ; generated key
+certfile=cert.pem          ; self-signed certificate
 nickname=sftbot
 channel=testchannel
 password=hunter2

--- a/sftbot/MumbleConnection.py
+++ b/sftbot/MumbleConnection.py
@@ -40,11 +40,13 @@ for k, v in messageTypes.items():
 class MumbleConnection(AbstractConnection.AbstractConnection):
 
     # call the superconstructor and set global configuration variables.
-    def __init__(self, hostname, port, nickname, channel, password, name,
+    def __init__(self, hostname, port, keyfile, certfile, nickname, channel, password, name,
                  loglevel):
         super(MumbleConnection, self).__init__(name, loglevel)
         self._hostname = hostname
         self._port = port
+        self._keyfile = keyfile
+        self._certfile = certfile
         self._nickname = nickname
         self._channel = channel
         self._password = password
@@ -66,23 +68,23 @@ class MumbleConnection(AbstractConnection.AbstractConnection):
         open the (SSL) socket and return True.
         # TODO: support server certificate validation, provide client cert
         """
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((self._hostname, self._port))
-            self._log("trying python default ssl socket", 3)
-            self._socket = ssl.wrap_socket(s)
-            return True
-        except ssl.SSLError:
-            try:
-                s.close()
-            except:
-                pass
+        #try:
+        #    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        #    s.connect((self._hostname, self._port))
+        #    self._log("trying python default ssl socket", 3)
+        #    self._socket = ssl.wrap_socket(s)
+        #    return True
+        #except ssl.SSLError:
+        #    try:
+        #        s.close()
+        #    except:
+        #        pass
 
         try:
             self._log("python default ssl connection failed, trying TLSv1", 2)
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.connect((self._hostname, self._port))
-            self._socket = ssl.wrap_socket(s, ssl_version=ssl.PROTOCOL_TLSv1)
+            self._socket = ssl.wrap_socket(s, self._keyfile, self._certfile, ssl_version=ssl.PROTOCOL_TLSv1, ciphers="AES256-SHA")
             return True
         except ssl.SSLError:
             try:

--- a/sftbot/__main__.py
+++ b/sftbot/__main__.py
@@ -112,6 +112,8 @@ def main():
     # configuration for the mumble connection
     mblservername = cparser.get('mumble', 'server')
     mblport = int(cparser.get('mumble', 'port'))
+    mblkeyfile = cparser.get('mumble', 'keyfile')
+    mblcertfile = cparser.get('mumble', 'certfile')
     mblnick = cparser.get('mumble', 'nickname')
     mblchannel = cparser.get('mumble', 'channel')
     mblpassword = cparser.get('mumble', 'password')
@@ -132,6 +134,8 @@ def main():
     mumble = MumbleConnection.MumbleConnection(
         mblservername,
         mblport,
+        mblkeyfile,
+        mblcertfile,
         mblnick,
         mblchannel,
         mblpassword,


### PR DESCRIPTION
Added fixes for using personal self-signed SSL certificates to the bot. This will allow users of the script to register their bot as a member of the server. I also added instructions to the README for generating self-signed certificates. If you have any questions or comments, I'm sitting on Freenode as JmactheAttack.