### PR TITLE
Fixed the way the bot breaks on large messages from a mumble server

### DIFF
--- a/sftbot/MumbleConnection.py
+++ b/sftbot/MumbleConnection.py
@@ -134,7 +134,22 @@ class MumbleConnection(AbstractConnection.AbstractConnection):
         else:
             raise Exception("expected 6 bytes, but got " + str(len(header)))
 
-        data = self._socket.recv(size)
+        if size < 4096:
+            data = self._socket.recv(size)
+            while len(data) < size:
+                data += self._socket.recv(size - len(data))
+        else:
+            data = self._socket.recv(4096)
+            tempsize = size - 4096
+            while tempsize > 4096:
+                newdata = self._socket.recv(4096)
+                while len(newdata) < 4096:
+                    newdata += self._socket.recv(4096 - len(newdata))
+                data += newdata
+                tempsize -= 4096
+            data += self._socket.recv(tempsize)
+            while len(data) < size:
+                data += self._socket.recv(size - len(data))
 
         # look up the message type and invoke the message type's constructor.
         try:

--- a/sftbot/__main__.py
+++ b/sftbot/__main__.py
@@ -14,14 +14,13 @@ console = None
 
 
 def mumbleTextMessageCallback(sender, message):
-    message.replace("<b>", "*").replace("</b>", "*")
-    line = "<" + sender + "> " + message
+    line = "<{}> {}".format(sender, message)
     console.sendTextMessage(line)
     irc.sendTextMessage(line)
 
 
 def ircTextMessageCallback(sender, message):
-    line = sender + ": " + message
+    line = "<b>{}</b>:{}".format(sender, message)
     console.sendTextMessage(line)
     mumble.sendTextMessage(line)
 

--- a/sftbot/__main__.py
+++ b/sftbot/__main__.py
@@ -14,21 +14,16 @@ console = None
 
 
 def mumbleTextMessageCallback(sender, message):
-    line = "mumble: " + sender + ": " + message
+    message.replace("<b>", "*").replace("</b>", "*")
+    line = "<" + sender + "> " + message
     console.sendTextMessage(line)
     irc.sendTextMessage(line)
-    if(message == 'gtfo'):
-        mumble.sendTextMessage("KAY CU")
-        mumble.stop()
 
 
 def ircTextMessageCallback(sender, message):
-    line = "irc: " + sender + ": " + message
+    line = sender + ": " + message
     console.sendTextMessage(line)
     mumble.sendTextMessage(line)
-    if (message == 'gtfo'):
-        irc.sendTextMessage("KAY CU")
-        irc.stop()
 
 
 def consoleTextMessageCallback(sender, message):


### PR DESCRIPTION
When size is large, the bot will try to get the full message with socket.recv(size), which breaks horribly. I fixed this with some changes to MumbleConnection.py. I made some personal changes to my fork in __main__.py that can be safely ignored, the actual changes are in MumbleConnection.py